### PR TITLE
Include binaries for WOW64 NaCl

### DIFF
--- a/build-release
+++ b/build-release
@@ -455,6 +455,8 @@ build () {
 		then
 			if "${arch_i686}"
 			then
+				engine_file_list="${engine_file_list} nacl_loader64.exe irt_core-x86_64.nexe" # WOW64 support
+
 				if "${host_windows}"
 				then
 					# MSYS2 uses the DWARF exception flavor


### PR DESCRIPTION
Include the NaCl support binaries needed when using the 32-bit engine on
64-bit Windows. The lack of these is a regression compared to the 0.51
release.