### PR TITLE
build-release: only zip files, not directories

### DIFF
--- a/build-release
+++ b/build-release
@@ -241,7 +241,11 @@ package () {
 			rm -v "${archive_filename}"
 		fi
 
-		7z -mx='9' -t"${archive_format}" a "${archive_filename}" .
+		# Only store files, not folders, folders will be recreated on extraction.
+		local file_list="$(mktemp)"
+		find . -type f | cut -c3- | sort > "${file_list}"
+		7z -mx='9' -snl -t"${archive_format}" a "${archive_filename}" -i@"${file_list}"
+		rm "${file_list}"
 	)
 }
 


### PR DESCRIPTION
Zip format does not require to store directory to store files in a directory. Storing directory is only required for storing directory metadata (like file modification date, etc.)

Not storing directories produces smaller zip files, the directories are automatically created when unzipping the files.