### PR TITLE
build-release: no need to delete the archive before packaging as the packager deletes it

### DIFF
--- a/build-release
+++ b/build-release
@@ -720,11 +720,6 @@ build () {
 
 		engine_archive_filename="${release_dir}/${engine_archive_basename}${engine_version_string}.${engine_archive_format}"
 
-		if [ -f "${engine_archive_filename}" ]
-		then
-			rm -v "${engine_archive_filename}"
-		fi
-
 		package "${engine_archive_format}" "${engine_archive_filename}" "${content_dir}"
 
 		cleanSymbols "${symbol_dir}" "${symbol_archive_filename}"


### PR DESCRIPTION
build-release: no need to delete the archive before packaging as the packager deletes it