### PR TITLE
build-release: use +dirty instead of -dirty version suffix when there are uncommitted files

### DIFF
--- a/build-release
+++ b/build-release
@@ -281,7 +281,7 @@ printVersion () {
 
 	if ! git diff --quiet 2>/dev/null
 	then
-		dirt_string='-dirty'
+		dirt_string='+dirty'
 	fi
 
 	echo "${tag_string}${date_string}${ref_string}${dirt_string}"


### PR DESCRIPTION
build-release: use +dirty instead of -dirty version suffix when there are uncommitted files

Because:

- 0.54-dirty > 0.54-20230315-205943-91a9359
- 0.54+dirty < 0.54-20230315-205943-91a9359

We want uncommitted files to produce a lower package version than the version the same files would produce once committed.

See:

- https://github.com/DaemonEngine/Urcheon/commit/8c7d2fba7c9bf6272142f9aa6a367f7eb4cee61a