### PR TITLE
docker-build: fix building for macos-amd64 by forcing the use of an old brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ options:
 
 ```
 
+## Requirements
+
+You need docker to use the `docker-build` script. To build the `macos-amd64` target, `docker` should be configured to use the [`btrfs` storage driver](https://docs.docker.com/storage/storagedriver/btrfs-driver/) since [`darling` does not run over overlayfs](https://docs.darlinghq.org/build-instructions.html#file-system-support).
+
 
 ## Building with the simple Dockerfile
 

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -35,8 +35,3 @@ _error () {
 	echo "${1}" >&2
 	exit 1
 }
-
-if [ "$(uname -s)" != 'Linux' -o "$(uname -m)" != 'x86_64' ]
-then
-	_error "This script must run on amd64 Linux system"
-fi

--- a/docker/install-brew-and-packages
+++ b/docker/install-brew-and-packages
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+echo 'y' | _exec xcode-select --install
+
+_exec touch /.dockerenv
+
+_exec curl -fsSL -o brew-install \
+	'https://raw.githubusercontent.com/Homebrew/install/a8c26acd449233fa2394930b440aac0c7047753c/install.sh'
+
+# See https://docs.brew.sh/Installation
+export NONINTERACTIVE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_ANALYTICS=1
+
+_exec ./brew-install
+
+# brew-install switches it off automatically
+export HOMEBREW_NO_INSTALL_FROM_API=1
+
+_exec git \
+	-C '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core' \
+	checkout '103f18b14fbe28e2ff10a39cae19a79a54d636ab'
+
+# curl is already available
+_exec brew install p7zip cmake

--- a/docker/install-darling-dependencies
+++ b/docker/install-darling-dependencies
@@ -30,24 +30,9 @@ if [ ! -f /darling-installed ]
 then
 	export DPREFIX=/darling-prefix
 
-	echo 'y' | _exec darling shell xcode-select --install
-
-	_exec darling shell touch /.dockerenv
-
-	_exec curl -fsSL -o brew-install \
-		'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh'
-
-	# See https://docs.brew.sh/Installation
-	export NONINTERACTIVE=1
-
-	_exec darling shell ./brew-install
-
-	_exec darling shell git \
-		-C '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core' \
-		checkout '103f18b14fbe28e2ff10a39cae19a79a54d636ab'
-
-	# curl is already available
-	_exec darling shell brew install p7zip cmake
+	cp "$(dirname "${BASH_SOURCE[0]}")/common.sh" .
+	cp "$(dirname "${BASH_SOURCE[0]}")/install-brew-and-packages" .
+	_exec darling shell ./install-brew-and-packages
 
 	_exec touch /darling-installed
 fi

--- a/docker/unvanquished-darling-system.Dockerfile
+++ b/docker/unvanquished-darling-system.Dockerfile
@@ -19,5 +19,6 @@ COPY docker/clone-repositories /docker
 COPY docker/build-targets /docker
 
 COPY docker/install-darling-dependencies /docker
+COPY docker/install-brew-and-packages /docker
 
 COPY build-release /


### PR DESCRIPTION
Fix building for macos-amd64 by forcing the use of an old brew:

- use `brew-install` from an old reference
- set `HOMEBREW_NO_INSTALL_FROM_API=1` so the local repository is used with old references

Darling emulates an old macOS, and then fetches an old xcode. Current brew doesn't support that old macOS, neither that old xcode.

We may want to build on older macOS the same way we do with older Debian for Linux anyway.

We use brew to install p7zip and cmake, we don't need it for anything else since we build the external_deps ourselves.

In the future we may rely on cmake binary tarball from cmake.org and build p7zip ourselves but using an old brew (and make sure it doesn't auto-update) is good enough to fix the build.

We now use a subscript so environment variables are set within darling and not outside of it.