### PR TITLE
docker: do not invalidate the system container when changing reference

### DIFF
--- a/docker-build
+++ b/docker-build
@@ -183,7 +183,7 @@ def main():
         targets_env="--env=targets={}".format(" ".join(common_target_list))
 
         # Install Debian and dependencies.
-        docker.run("build", ["unvanquished-common-system", targets_arg, reference_arg])
+        docker.run("build", ["unvanquished-common-system", targets_arg])
 
         # Clone source repositories and build external dependencies.
         docker.run("build", ["unvanquished-common-source", targets_arg, reference_arg])
@@ -202,7 +202,7 @@ def main():
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
 
         # Install Ubuntu, Darling, Xcode and other dependencies.
-        docker.run("build", ["unvanquished-darling-system", targets_arg, reference_arg])
+        docker.run("build", ["unvanquished-darling-system", targets_arg])
 
         after, err = docker.run("inspect", inspect_system_command_list,
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)

--- a/docker/unvanquished-common-system.Dockerfile
+++ b/docker/unvanquished-common-system.Dockerfile
@@ -11,9 +11,6 @@ RUN test -n "${targets}"
 COPY docker/install-system-dependencies /docker
 RUN /docker/install-system-dependencies
 
-ARG reference
-RUN test -n "${reference}"
-
 COPY docker/clone-repositories /docker
 
 COPY docker/build-external-dependencies /docker

--- a/docker/unvanquished-darling-system.Dockerfile
+++ b/docker/unvanquished-darling-system.Dockerfile
@@ -11,9 +11,6 @@ RUN test -n "${targets}"
 COPY docker/install-system-dependencies /docker
 RUN /docker/install-system-dependencies
 
-ARG reference
-RUN test -n "${reference}"
-
 COPY docker/clone-repositories /docker
 
 COPY docker/build-targets /docker


### PR DESCRIPTION
Do not invalidate the system container when changing reference.

Not only it saves time for every target, but the brew installation in darling is a bit fragile and sometime gets stuck and should be restarted. Once it has succeeded once, we better keep the precious working container as long as possible and not destroy it every time a release candidate is to be built (or another reference someone wants to build).