### PR TITLE
docker: make possible to only build the engine without committing it to Unvanquished

### DIFF
--- a/build-release
+++ b/build-release
@@ -480,6 +480,8 @@ build () {
 		cmake_opts="${cmake_opts} -DBUILD_GAME_NACL=ON -DBUILD_GAME_NACL_NEXE=ON -DBUILD_CGAME=ON -DBUILD_SGAME=ON -DBUILD_CLIENT=OFF -DBUILD_TTY_CLIENT=OFF -DBUILD_SERVER=OFF"
 	fi
 
+	local daemon_dir="${root_dir}/daemon"
+
 	if "${build_engine}"
 	then
 		engine_archive_basename="${target}"
@@ -498,7 +500,7 @@ build () {
 			fi
 
 			strip="${mingw_arch_prefix}-w64-mingw32-strip"
-			cmake_opts="${cmake_opts} -DCMAKE_TOOLCHAIN_FILE=${root_dir}/daemon/cmake/cross-toolchain-mingw${bitness}.cmake"
+			cmake_opts="${cmake_opts} -DCMAKE_TOOLCHAIN_FILE=${daemon_dir}/cmake/cross-toolchain-mingw${bitness}.cmake"
 			# unused
 			# cmake_opts="${cmake_opts} -DPKG_CONFIG_EXECUTABLE=${mingw_arch_prefix}-w64-mingw32-pkg-config"
 		fi
@@ -578,7 +580,7 @@ build () {
 			fi
 
 			strip="${mingw_arch_prefix}-w64-mingw32-strip"
-			cmake_opts="${cmake_opts} -DCMAKE_TOOLCHAIN_FILE=${root_dir}/daemon/cmake/cross-toolchain-mingw${bitness}.cmake"
+			cmake_opts="${cmake_opts} -DCMAKE_TOOLCHAIN_FILE=${daemon_dir}/cmake/cross-toolchain-mingw${bitness}.cmake"
 			# unused
 			# cmake_opts="${cmake_opts} -DPKG_CONFIG_EXECUTABLE=${mingw_arch_prefix}-w64-mingw32-pkg-config"
 		fi
@@ -599,7 +601,7 @@ build () {
 	then
 		# configuration
 
-		cmake -H"${root_dir}" \
+		cmake -H"${daemon_dir}" \
 			-B"${target_build_dir}" \
 			-G"Unix Makefiles" \
 			-D"CMAKE_C_FLAGS=${cmake_cflags}" \
@@ -607,11 +609,6 @@ build () {
 			-D"CMAKE_EXE_LINKER_FLAGS=${cmake_cflags}" \
 			${cmake_opts} \
 		|| throwError INTERNAL "${target} cmake failed"
-	fi
-
-	if "${build_vm}" || "${build_engine}"
-	then
-		daemon_dir="$(cmake -H"${root_dir}" -B"${target_build_dir}" -LH | grep '^DAEMON_DIR:' | sed -e 's/[^=]*=//')"
 	fi
 
 	if "${build_vm}"

--- a/docker-build
+++ b/docker-build
@@ -115,8 +115,9 @@ def main():
     parser.add_argument("--clean", dest="clean", help="Delete previous target and universal zip builds.", action="store_true")
     parser.add_argument("--prune", dest="prune", help="Delete all docker images from previous target builds.", action="store_true")
     parser.add_argument("--reimage", dest="reimage", help="Rebuild the system docker images for the targets to build.", action="store_true")
-    parser.add_argument("--reference", dest="reference", metavar="REFERENCE", nargs='?', help="Git reference for targets to build.")
-    parser.add_argument("--targets", dest="targets", metavar="TARGETS", nargs='+', help="List of targets. Requires a reference. Available targets: {}".format(known_target_option_list))
+    parser.add_argument("--reference", dest="reference", metavar="REFERENCE", nargs='?', default="default", help="Git reference for targets to build.")
+    parser.add_argument("--engine-reference", dest="engine_reference", metavar="ENGINE_REFERENCE", nargs='?', default="default", help="Git reference for engine targets to build.")
+    parser.add_argument("--targets", dest="targets", metavar="TARGETS", nargs='+', help="List of targets. Available targets: {}".format(known_target_option_list))
     parser.add_argument("--unizip", dest="unizip", help="Make an universal zip out of built targets.", action="store_true")
     parser.add_argument("--chown", dest="chown", help="Change ownership of produced files, this option should never be needed as other tasks are expected to do it.", action="store_true")
     parser.add_argument("--docker", dest="docker", metavar="PATH", default="docker", help="Path to the docker binary. Default: %(default)s.")
@@ -124,9 +125,6 @@ def main():
     args = parser.parse_args()
 
     docker = Docker(args.docker)
-
-    if args.targets and not args.reference:
-        error("Building a target requires a reference.")
 
     target_list = []
 
@@ -150,7 +148,8 @@ def main():
     print("Clean: {}".format(str(args.clean)))
     print("Prune: {}".format(str(args.prune)))
     print("Reimage: {}".format(str(args.reimage)))
-    print("Reference: {}".format(str(args.reference)))
+    print("reference: {}".format(str(args.reference)))
+    print("Engine reference: {}".format(str(args.engine_reference)))
     print("Targets: {}".format(target_list_string))
     print("Unizip: {}".format(str(args.unizip)))
     print("Chown: {}".format(str(args.chown)))
@@ -174,6 +173,7 @@ def main():
 
     if target_list:
         reference_arg="--build-arg=reference={}".format(args.reference)
+        engine_reference_arg = "--build-arg=engine_reference={}".format(args.engine_reference)
 
         if args.reimage:
             docker.run("rmi", ["unvanquished-common-system"], stderr=subprocess.DEVNULL)
@@ -186,7 +186,7 @@ def main():
         docker.run("build", ["unvanquished-common-system", targets_arg])
 
         # Clone source repositories and build external dependencies.
-        docker.run("build", ["unvanquished-common-source", targets_arg, reference_arg])
+        docker.run("build", ["unvanquished-common-source", targets_arg, reference_arg, engine_reference_arg])
 
         # Build the targets.
         docker.run("mrun", ["--rm", targets_env,
@@ -243,7 +243,7 @@ def main():
             docker.run("commit", [container_id, "unvanquished-darling-darling"])
 
         # Clone source repositories.
-        docker.run("build", ["unvanquished-darling-source", reference_arg])
+        docker.run("build", ["unvanquished-darling-source", reference_arg, engine_reference_arg])
 
         # Build the targets.
         docker.run("mrun", ["--privileged", "--rm", targets_env,

--- a/docker/clone-repositories
+++ b/docker/clone-repositories
@@ -26,15 +26,22 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-# Assume the desired revision of Unvanquished is near the tip
-# of some branch (last 20 commits)
-_exec git clone --depth 20 --no-single-branch \
-	'https://github.com/Unvanquished/Unvanquished.git' '/Unvanquished'
+_exec git clone 'https://github.com/Unvanquished/Unvanquished.git' '/Unvanquished'
 
 cd '/Unvanquished'
 
-_exec git checkout "${reference}"
+if [ "${reference:-default}" != 'default' ]
+then
+	_exec git checkout "${reference}"
+fi
 
-_exec git submodule update --init --depth 1 --recursive
+_exec git submodule update --init --recursive
+
+if [ "${engine_reference:-default}" != 'default' ]
+then
+	_exec git -C daemon checkout "${engine_reference}"
+
+	_exec git -C daemon submodule update --init --recursive
+fi
 
 _exec mkdir -p '/Unvanquished/build/release'

--- a/docker/unvanquished-common-source.Dockerfile
+++ b/docker/unvanquished-common-source.Dockerfile
@@ -4,7 +4,8 @@ ARG targets
 RUN test -n "${targets}"
 
 ARG reference
-RUN test -n "${reference}"
+
+ARG engine_reference
 
 RUN /docker/clone-repositories
 

--- a/docker/unvanquished-darling-source.Dockerfile
+++ b/docker/unvanquished-darling-source.Dockerfile
@@ -1,6 +1,7 @@
 FROM unvanquished-darling-darling
 
 ARG reference
-RUN test -n "${reference}"
+
+ARG engine_reference
 
 RUN /docker/clone-repositories


### PR DESCRIPTION
One can only build the engine by doing:

```
./docker-build --engine-reference=<git_reference> --targets=<engine_target>
```

The reference for the game is now optional, the current master branch will be built if not set. The currently committed engine reference for the game reference will be built if the engine reference is not set.

The repository clone is now complete, instead of doing a shadow clone. This makes easier to checkout arbitrary commits, and in the future this will ensure the most recent tag is reachable, to compute the version string.