### PR TITLE
docker: use newer CMake from buster-backports

### DIFF
--- a/docker/install-system-dependencies
+++ b/docker/install-system-dependencies
@@ -153,6 +153,17 @@ _exec apt-get update
 
 _exec apt-get install --yes "${system_packages[@]}"
 
+# Install newer cmake on Debian Buster.
+_exec apt-get install --yes lsb-release
+if [ "$(lsb_release -sc)" = 'buster' ]
+then
+	_exec apt-get install --yes ca-certificates.
+	echo 'deb https://archive.debian.org/debian-archive/debian buster-backports main' \
+	| _exec tee '/etc/apt/sources.list.d/debian-buster-backports.list' >/dev/null
+	_exec apt-get update
+	_exec apt-get install --yes -t buster-backports cmake
+fi
+
 for alternative_pair in "${alternative_pairs[@]}"
 do
 	_exec update-alternatives --set ${alternative_pair}


### PR DESCRIPTION
Use newer CMake from `buster-backports`.

This makes possible to upgrade out `external_deps`, as some now require a newer CMake than the one provided by Debian Buster:

- https://github.com/DaemonEngine/Daemon/pull/1433

For example the recent libPNG requires CMake 3.14 or higher, but Debian Buster only provides CMake 3.13.4 in its stock repositories. The `debian-backports` repository provides CMake 3.18.4 which gives use plenty of time before needing an even higher CMake.

The code tests for the distribution being `buster` because the same script is also used for the Darling docker for macOS build which is running Ubuntu Focal. This also makes easier to test for newer Debian distributions for the Linux/MinGW builds.