### PR TITLE
release-build: disable PCH when building the macOS engine in Darling

### DIFF
--- a/build-release
+++ b/build-release
@@ -456,7 +456,7 @@ build () {
 	mkdir -pv "${target_build_dir}"
 	mkdir -pv "${release_dir}"
 
-	local cmake_opts='-DBUILD_GAME_NATIVE_DLL=OFF -DBUILD_GAME_NATIVE_EXE=OFF'
+	local cmake_opts='-DBUILD_GAME_NATIVE_DLL=OFF -DBUILD_GAME_NATIVE_EXE=OFF -DUSE_PRECOMPILED_HEADER=OFF'
 	local cmake_cflags=''
 
 	if "${system_macos}"


### PR DESCRIPTION
The Clang available in the Darling environment doesn't support PCH properly. It doesn't report PCH is not supported, but the build is plagued with garbage from the header files when doing so.

Fix DaemonEngine/Daemon#1622:

- https://github.com/DaemonEngine/Daemon/issues/1622