### PR TITLE
docker: fix the nacl_loader scons build for linux-amd64

### DIFF
--- a/docker/build-external-dependencies
+++ b/docker/build-external-dependencies
@@ -34,7 +34,11 @@ do
 	vm)
 		# HACK: naclsdk is installed twice when building
 		# both vm and linux-amd64-default.
-		_exec ./build.sh 'linux-amd64-default' naclsdk naclports install
+		_exec ./build.sh 'linux-amd64-default' naclsdk install
+		;;
+	linux-amd64)
+		# We currently only rebuild the nacl_loader on linux-amd64.
+		_exec ./build.sh "${target}-default" ogg opus opusfile curl sdl2 glew webp openal ncurses naclruntime naclsdk install
 		;;
 	linux-*)
 		# Build some static libraries in the cases the package manager

--- a/docker/install-system-dependencies
+++ b/docker/install-system-dependencies
@@ -28,10 +28,18 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 export DEBIAN_FRONTEND='noninteractive'
 
+# TODO: Remove scons and python3 onces the NaCl loader builds with CMake.
+# TODO: Remove clang onces the NaCl loader builds with GCC.
+# TODO: Remove unzip onces the NaCl loader archive uses another format than zip
+# or the build script is modified to use 7z when it is there.
 system_packages=(
 	git
 	curl
 	p7zip-full
+	scons
+	python3
+	clang
+	unzip
 )
 
 # Toolchain dependencies for Unvanquished, Daemon, external_packages, or build-release


### PR DESCRIPTION
Fix the `nacl_loader` `scons` build for `linux-amd64`.