### PR TITLE
Use fully qualified remote Docker image names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM docker.io/debian:bullseye-slim
 
 # Toolchain dependencies for Unvanquished, Daemon, external_deps, or build-release
 ENV TOOLCHAIN_DEPS=' \

--- a/docker/unvanquished-chown-system.Dockerfile
+++ b/docker/unvanquished-chown-system.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM docker.io/debian:trixie-slim
 
 RUN mkdir /docker
 COPY docker/common.sh /docker

--- a/docker/unvanquished-darling-system.Dockerfile
+++ b/docker/unvanquished-darling-system.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM docker.io/ubuntu:focal
 
 ARG build_macos=true
 

--- a/docker/unvanquished-linux-system.Dockerfile
+++ b/docker/unvanquished-linux-system.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM docker.io/debian:bullseye-slim
 
 ARG build_linux=true
 

--- a/docker/unvanquished-mingw-system.Dockerfile
+++ b/docker/unvanquished-mingw-system.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM docker.io/debian:trixie-slim
 
 ARG build_windows=true
 

--- a/docker/unvanquished-unizip-system.Dockerfile
+++ b/docker/unvanquished-unizip-system.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM docker.io/debian:trixie-slim
 
 RUN mkdir /docker
 COPY docker/common.sh /docker

--- a/docker/unvanquished-vm-system.Dockerfile
+++ b/docker/unvanquished-vm-system.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM docker.io/debian:trixie-slim
 
 ARG build_vm=true
 


### PR DESCRIPTION
Avoids package squatting vulnerabilities in the presence of multiple registries a la
https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610.